### PR TITLE
Core functionality.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -87,7 +87,9 @@
 		"require",
 		"module",
 		"describe",
-		"it"
+		"it",
+		"before",
+		"beforeEach"
 	],
 
 	// LEGACY

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The follow methods are added to the `seriate` instance:
 |method name         | description              |
 |--------------------|--------------------------|
 |`addMock(key, config)` | Stores the mock in the cache to be retrieved later
+|`addFileMock(path, config)` | Stores a mock for use when `sql.fromFile()` is called
 |`clearMock([key])` | Removes specific mock from cache if key is provided or clears all mocks if no key is provided.
 |`getMock(key)` | Retrieves mock from cache
 |`resolveMock(stepName, stepConfig)` | Retrieves the correct mock to be used for a particular SQL Context step.
@@ -72,14 +73,133 @@ sql.getPlainContext()
 
 **Warning:** *Giving `addMock` a plain object will not work the way you think it does.*
 
-When passing a plain object to `addMock` it must be in the form of a raw mock object:
+When passing a plain object to `addMock` it must be in the form of a raw mock object including at least the `mockResults` key:
 
 ```javascript
 // ...
 
 sql.addMock( "ninjaTurtles", {
 	mockResults: [ 'Leonardo', 'Donatello', 'Raphael', 'Michelangelo' ], // This can be any data type including a function
-	isError: false, // If true, results will be passed to query error handler
-	waitTime: 1000, // Time in milliseconds to wait for query to resolve
+	isError: false, // [Default false] If true, results will be passed to query error handler
+	waitTime: 1000, // [Default 0] Time in milliseconds to wait for query to resolve
+	once: false // [Default false] If true, mock will be discarded after one use
 });
+```
+
+The API works the same way with Seriate's `TransactionContext` object:
+
+```javascript
+sql.addMock( "dogs", [ "German Shepherds", "Labradors", "Dobermans" ] );
+
+sql.getTransactionContext()
+	.step( "dogs" )
+	.end( function( sets ) {
+		sets.dogs; // [ "German Shepherds", "Labradors", "Dobermans" ]
+	});
+```
+
+**Warning:** *Using this library will mock all transaction contexts. You will not be able to perform actual transactions at any point.*
+
+You can mock calls to `execute` or `first` by using the query (or preparedSql) as the key:
+
+```javascript
+sql.addMock( "SELECT * FROM sys.books", [
+	"A Tale of Two Cities",
+	"The Jungle",
+	"Heart of Darkness"
+] );
+
+sql.execute({
+		query: "SELECT * FROM sys.books"
+	})
+	.end(function( results ) {
+		results; // [ "A Tale of Two Cities", "The Jungle", "Heart of Darkness" ]
+	});
+
+sql.first({
+		query: "SELECT * FROM sys.books"
+	})
+	.end(function( result ) {
+		result; // "A Tale of Two Cities"
+	});
+```
+
+You might consider using the `once` parameter single use mocks to avoid collisions without having to remember to clear the mock manually.
+
+```javascript
+sql.addMock( "SELECT * FROM sys.books", [
+	"A Tale of Two Cities",
+	"The Jungle",
+	"Heart of Darkness"
+], { once: true } );
+
+sql.execute({
+		query: "SELECT * FROM sys.books"
+	})
+	.end(function( results ) {
+		results; // [ "A Tale of Two Cities", "The Jungle", "Heart of Darkness" ]
+	});
+
+sql.first({
+		query: "SELECT * FROM sys.books"
+	})
+	.end(function( result ) {
+		result; // Mock no longer exists and will not be found
+	});
+```
+
+####File Mocking
+
+You can mock by file access by using the `addFileMock` method.
+
+```javascript
+var expectedResults = [{ name: "Neo" }, { name: "Trinity" }, { name: "Morpheus" }];
+
+sql.addFileMock( "./matrixCharacters", function( stepName, stepArg ) {
+	return expectedResults;
+} );
+
+sql.getPlainContext()
+	.step( "characters", {
+		preparedSql: sql.fromFile( "./matrixCharacters" ),
+	})
+	.end( function( sets ) {
+		sets.characters; // [{ name: "Neo" }, { name: "Trinity" }, { name: "Morpheus" }]
+	} );
+```
+
+The file mocks will try to resolve to the same absolute path as the value given to `sql.fromFile`. Set the configuration option `sqlFileBasePath` to form the basis for your absolute paths built by `addFileMock`. For instance;
+
+
+```javascript
+// Filename: /Users/me/myProject/src/lib/somefile.js
+
+sql.getPlainContext()
+	.step( "characters", {
+		preparedSql: sql.fromFile( "./matrixCharacters" ),
+	})
+	.end( function( sets ) {
+		sets.characters; // [{ name: "Neo" }, { name: "Trinity" }, { name: "Morpheus" }]
+	} );
+
+// File will resolve to /Users/me/myProject/src/lib/matrixCharacters
+```
+
+To mock this file from an external test, you would do something like this:
+
+```javascript
+// Filename: /Users/me/myProject/spec/lib/somefile.spec.js
+
+var sql = require( "seriate" );
+var mock = require( "seriate.mock" );
+
+mock( sql, { sqlFileBasePath: "/Users/me/myProject/src"} );
+
+var expectedResults = [{ name: "Neo" }, { name: "Trinity" }, { name: "Morpheus" }];
+
+sql.addFileMock( "lib/matrixCharacters", function( stepName, stepArg ) {
+	return expectedResults;
+} );
+
+// Mock file will resolve to /Users/me/myProject/src/lib/matrixCharacters
 ```

--- a/spec/addMockBehavior.spec.js
+++ b/spec/addMockBehavior.spec.js
@@ -21,7 +21,7 @@ describe( "When adding a mock", function() {
 
 			sql.addMock( "myMock", mockObj );
 
-			expect( sql.mockCache.myMock ).to.eql( _.merge( { waitTime: 0 }, mockObj ) );
+			expect( sql.mockCache[ "root" ].myMock ).to.eql( _.merge( { waitTime: 0 }, mockObj ) );
 		} );
 		it( "should ensure that mockResults is a function", function() {
 			var mockObj = {
@@ -30,7 +30,7 @@ describe( "When adding a mock", function() {
 
 			sql.addMock( "myMock", mockObj );
 
-			var result = sql.mockCache.myMock.mockResults;
+			var result = sql.mockCache[ "root" ].myMock.mockResults;
 			expect( result ).to.be.a( "function" );
 			expect( result() ).to.equal( "something" );
 		} );
@@ -43,9 +43,9 @@ describe( "When adding a mock", function() {
 				return "results";
 			} );
 
-			var thisMock = sql.mockCache.myMock;
+			var thisMock = sql.mockCache[ "root" ].myMock;
 
-			var result = sql.mockCache.myMock.mockResults;
+			var result = sql.mockCache[ "root" ].myMock.mockResults;
 			expect( thisMock.mockResults ).to.be.a( "function" );
 			expect( thisMock.mockResults() ).to.equal( "results" );
 			expect( thisMock.isError ).to.not.be.ok();
@@ -58,9 +58,9 @@ describe( "When adding a mock", function() {
 			var expected = [ 'val1', 'val2', 'val3' ];
 			sql.addMock( "myMock", expected );
 
-			var thisMock = sql.mockCache.myMock;
+			var thisMock = sql.mockCache[ "root" ].myMock;
 
-			var result = sql.mockCache.myMock.mockResults;
+			var result = sql.mockCache[ "root" ].myMock.mockResults;
 			expect( thisMock.mockResults ).to.be.a( "function" );
 			expect( thisMock.mockResults() ).to.eql( expected );
 			expect( thisMock.isError ).to.not.be.ok();

--- a/spec/addMockBehavior.spec.js
+++ b/spec/addMockBehavior.spec.js
@@ -21,7 +21,7 @@ describe( "When adding a mock", function() {
 
 			sql.addMock( "myMock", mockObj );
 
-			expect( sql.mockCache[ "root" ].myMock ).to.eql( _.merge( { waitTime: 0 }, mockObj ) );
+			expect( sql.mockCache[ "root" ].myMock ).to.eql( _.merge( { waitTime: 0, once: false }, mockObj ) );
 		} );
 		it( "should ensure that mockResults is a function", function() {
 			var mockObj = {

--- a/spec/executeBehavior.spec.js
+++ b/spec/executeBehavior.spec.js
@@ -1,0 +1,75 @@
+var mock = require( "../src/index.js" );
+var expect = require( "expect.js" );
+var _ = require( "lodash" );
+
+describe( "When mocking one-time queries", function() {
+	var sql = require( "seriate" );
+	var records = [
+		{ title: "Kanban", author: "David Anderson" },
+		{ title: "Gunsmithing Rifles", author: "Patrick Sweeney" },
+		{ title: "Programming Ruby", author: "Dave Thomas" }
+	];
+
+	before( function() {
+		mock( sql );
+	} );
+
+	beforeEach( function() {
+		sql.clearMock();
+	} );
+
+	describe( "when mocking an execute() call", function() {
+		it( "should support mocking by query", function( done ) {
+			sql.addMock( "SELECT * FROM books", records );
+
+			sql.execute( {
+				query: "SELECT * FROM books"
+			} )
+				.then( function( sets ) {
+					expect( sets ).to.eql( records );
+					done();
+				} );
+
+		} );
+
+		it( "should support mocking by preparedSql", function( done ) {
+			sql.addMock( "SELECT * FROM books", records );
+
+			sql.execute( {
+				preparedSql: "SELECT * FROM books"
+			} )
+				.then( function( sets ) {
+					expect( sets ).to.eql( records );
+					done();
+				} );
+		} );
+	} );
+
+	describe( "when mocking a first() call", function() {
+		it( "should support mocking by query", function( done ) {
+			sql.addMock( "SELECT * FROM books", records );
+
+			sql.first( {
+				query: "SELECT * FROM books"
+			} )
+				.then( function( sets ) {
+					expect( sets ).to.eql( records[ 0 ] );
+					done();
+				} );
+		} );
+
+		it( "should support mocking by preparedSql", function( done ) {
+			sql.addMock( "SELECT * FROM books", records );
+
+			sql.first( {
+				preparedSql: "SELECT * FROM books"
+			} )
+				.then( function( sets ) {
+					expect( sets ).to.eql( records[ 0 ] );
+					done();
+				} );
+		} );
+	} );
+
+
+} );

--- a/spec/mock.spec.js
+++ b/spec/mock.spec.js
@@ -69,7 +69,7 @@ describe( "When getting a mock", function() {
 
 		it( "should return undefined if key is 'result'", function() {
 			var expected = [ 'val1', 'val2', 'val3' ];
-			sql.addMock( "result", expected );
+			sql.addMock( "__result__", expected );
 
 			var myMock = sql.getMock( "result" );
 

--- a/spec/mock.spec.js
+++ b/spec/mock.spec.js
@@ -11,13 +11,13 @@ describe( "When clearing a mock", function() {
 			sql.addMock( "myMock", [ 'val1', 'val2', 'val3' ] );
 			sql.addMock( "myMock2", [ 'val4', 'val5', 'val6' ] );
 
-			expect( sql.mockCache.myMock ).to.be.an( "object" );
-			expect( sql.mockCache.myMock2 ).to.be.an( "object" );
+			expect( sql.mockCache[ "root" ].myMock ).to.be.an( "object" );
+			expect( sql.mockCache[ "root" ].myMock2 ).to.be.an( "object" );
 
 			sql.clearMock( "myMock" );
 
-			expect( sql.mockCache.myMock ).to.not.be.an( "object" );
-			expect( sql.mockCache.myMock2 ).to.be.an( "object" );
+			expect( sql.mockCache[ "root" ].myMock ).to.not.be.an( "object" );
+			expect( sql.mockCache[ "root" ].myMock2 ).to.be.an( "object" );
 		} );
 
 	} );
@@ -27,13 +27,13 @@ describe( "When clearing a mock", function() {
 			sql.addMock( "myMock", [ 'val1', 'val2', 'val3' ] );
 			sql.addMock( "myMock2", [ 'val4', 'val5', 'val6' ] );
 
-			expect( sql.mockCache.myMock ).to.be.an( "object" );
-			expect( sql.mockCache.myMock2 ).to.be.an( "object" );
+			expect( sql.mockCache[ "root" ].myMock ).to.be.an( "object" );
+			expect( sql.mockCache[ "root" ].myMock2 ).to.be.an( "object" );
 
 			sql.clearMock();
 
-			expect( sql.mockCache.myMock ).to.not.be.an( "object" );
-			expect( sql.mockCache.myMock2 ).to.not.be.an( "object" );
+			expect( sql.mockCache ).to.be.empty();
+
 		} );
 
 	} );

--- a/spec/mockFileBehavior.spec.js
+++ b/spec/mockFileBehavior.spec.js
@@ -19,7 +19,7 @@ describe( "When adding a file mock", function() {
 	it( "should return the correct results", function( done ) {
 		var expectedResults = { name: "Neo", alias: "The One" };
 
-		sql.addMockFile( "./spec/userById", function( stepName, stepArg ) {
+		sql.addFileMock( "./spec/userById", function( stepName, stepArg ) {
 			return expectedResults;
 		} );
 

--- a/spec/mockFileBehavior.spec.js
+++ b/spec/mockFileBehavior.spec.js
@@ -1,0 +1,48 @@
+var mock = require( "../src/index.js" );
+var expect = require( "expect.js" );
+var _ = require( "lodash" );
+
+describe( "When adding a file mock", function() {
+	var sql = require( "seriate" );
+	before( function() {
+		mock( sql, {
+			sqlFileBasePath: __dirname + "/../"
+		} );
+	} );
+
+
+	beforeEach( function() {
+		sql.clearMock();
+	} )
+
+
+	it( "should return the correct results", function( done ) {
+		var expectedResults = { name: "Neo", alias: "The One" };
+
+		sql.addMockFile( "./spec/userById", function( stepName, stepArg ) {
+			return expectedResults;
+		} );
+
+		sql.getPlainContext()
+			.step( "user", {
+				preparedSql: sql.fromFile( "./userById" ),
+				params: {
+					boardId: {
+						val: 1,
+						type: sql.INT
+					},
+					laneId: {
+						val: 2,
+						type: sql.INT
+					}
+				}
+			}
+			)
+			.end( function( sets ) {
+				expect( sets.user ).to.eql( expectedResults );
+				done();
+			} );
+
+	} );
+
+} );

--- a/spec/transactionContextMockBehavior.spec.js
+++ b/spec/transactionContextMockBehavior.spec.js
@@ -1,10 +1,11 @@
 var mock = require( "../src/index.js" );
 var expect = require( "expect.js" );
+var _ = require( "lodash" );
 var sql = require( "seriate" );
 
 mock( sql );
 
-describe( "Plain Context Mocking behavior", function() {
+describe( "Transaction Context Mocking behavior", function() {
 
 	beforeEach( function() {
 		sql.clearMock();
@@ -30,14 +31,14 @@ describe( "Plain Context Mocking behavior", function() {
 			} );
 		} );
 		it( "should produce correct mock results", function( done ) {
-			sql.getPlainContext()
+			sql.getTransactionContext()
 				.step( "guise", {
 					params: {
 						testval: "foo"
 					}
 				} )
-				.end( function( sets ) {
-					expect( sets.guise ).to.eql( expectedResult );
+				.end( function( results ) {
+					expect( results.sets.guise ).to.eql( expectedResult );
 					done();
 				} );
 		} );
@@ -60,12 +61,12 @@ describe( "Plain Context Mocking behavior", function() {
 			] );
 		} );
 		it( "should produce correct mock results", function( done ) {
-			sql.getPlainContext()
+			sql.getTransactionContext()
 				.step( "guise", {
 					testval: "foo"
 				} )
-				.end( function( sets ) {
-					expect( sets.guise ).to.eql( expectedResult );
+				.end( function( results ) {
+					expect( results.sets.guise ).to.eql( expectedResult );
 					done();
 				} );
 		} );
@@ -77,8 +78,8 @@ describe( "Plain Context Mocking behavior", function() {
 			sql.addMock( 'someMock', {
 				mockResults: expectedResult,
 				isError: true
-			} );
-			sql.getPlainContext()
+			} )
+			sql.getTransactionContext()
 				.step( "someMock", {
 					params: {
 						testval: "foo"
@@ -93,71 +94,26 @@ describe( "Plain Context Mocking behavior", function() {
 
 	describe( "When mock contains a specified timeout", function() {
 		it( "should wait appropriately to execute", function( done ) {
-			this.timeout( 3000 );
+			this.timeout( 5000 );
 			var start = Date.now();
 
 			var expectedResult = [ "thing1", "thing2" ];
 			sql.addMock( 'someMock', {
 				mockResults: expectedResult,
 				waitTime: 1000
-			} );
-
-			sql.getPlainContext()
+			} )
+			sql.getTransactionContext()
 				.step( "someMock", {
 					params: {
 						testval: "foo"
 					}
 				} )
-				.end( function( sets ) {
+				.end( function( results ) {
 					var interval = Date.now() - start;
 					expect( interval >= 1000 && interval < 2000 ).to.be.ok();
-					expect( sets.someMock ).to.eql( expectedResult );
+					expect( results.sets.someMock ).to.eql( expectedResult );
 					done();
 				} );
-		} );
-	} );
-
-	describe( "'once' option", function() {
-		var expectedResult = [ { name: "HereIAmRockYouLikeAHurricane" } ];
-
-		describe( "when once is false (by default)", function() {
-			it( "should keep the mock after use", function( done ) {
-				sql.addMock( 'someMock', {
-					mockResults: expectedResult,
-					once: false
-				} );
-				sql.getPlainContext()
-					.step( "someMock", {
-						params: {
-							testval: "foo"
-						}
-					} )
-					.end( function( sets ) {
-						expect( sets.someMock ).to.eql( expectedResult );
-						expect( sql.mockCache.root.someMock ).to.not.be( undefined );
-						done();
-					} );
-			} );
-		} );
-
-		describe( "when once is true", function() {
-			it( "should dispose of mock after one use", function( done ) {
-				sql.addMock( 'someMock', {
-					mockResults: expectedResult,
-					once: true
-				} );
-				sql.getPlainContext()
-					.step( "someMock", {
-						params: {
-							testval: "foo"
-						}
-					} )
-					.end( function( sets ) {
-						expect( sets.someMock ).to.eql( expectedResult );
-						expect( sql.mockCache.root.someMock ).to.be( undefined );
-						done();
-					} );
-			} );
 		} );
 	} );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-var mock = require("./mock.js");
+var mock = require( "./mock.js" );
 
-module.exports = function seriate_mock( sql ) {
-	mock.setup( sql );
+module.exports = function seriate_mock( sql, options ) {
+	mock.setup( sql, options );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var mock = require( "./mock.js" );
 
-module.exports = function seriate_mock( sql, options ) {
+module.exports = function seriateMock( sql, options ) {
 	mock.setup( sql, options );
 };

--- a/src/methods.js
+++ b/src/methods.js
@@ -56,7 +56,7 @@ module.exports = {
 		this.mockCache[ cacheKey ][ key ] = realMock;
 	},
 
-	addMockFile: function( filePath, mock ) {
+	addFileMock: function( filePath, mock ) {
 		var absPath = path.resolve( this.getMockConfig( "sqlFileBasePath" ), filePath );
 		this.addMock( absPath, mock, { cacheKey: "file" } );
 	},

--- a/src/methods.js
+++ b/src/methods.js
@@ -1,0 +1,165 @@
+var path = require( "path" );
+var _ = require( "lodash" );
+
+function getCacheKey( options ) {
+	options = options || {};
+	return options.cacheKey || "root";
+}
+
+function isFileMock( str ) {
+	return str.slice( 0, 7 ) === "file://";
+}
+
+function getFileMockKey( str ) {
+	return str.slice( 7 );
+}
+
+module.exports = {
+	addMock: function( key, mock, options ) {
+		var cacheKey = getCacheKey( options );
+		var realMock = mock;
+		var defaults = {
+			isError: false,
+			once: false,
+			waitTime: 0
+		};
+
+		if ( !this.mockCache[ cacheKey ] ) {
+			this.mockCache[ cacheKey ] = {};
+		}
+
+		if ( _.isFunction( realMock ) ) {
+			// Just a function was given
+			realMock = _.merge( defaults, {
+				mockResults: mock,
+			} );
+		} else if ( !_.isPlainObject( realMock ) ) {
+			// Something other than a function or object was given
+			var result = _.clone( realMock );
+			realMock = _.merge( defaults, {
+				mockResults: function() {
+					return result;
+				}
+			} );
+		} else {
+			realMock = _.merge( defaults, mock );
+		}
+
+		if ( !_.isFunction( realMock.mockResults ) ) {
+			// Ensure that mockResults is a function
+			var results = _.clone( realMock.mockResults );
+			realMock.mockResults = function() {
+				return results;
+			};
+		}
+
+		this.mockCache[ cacheKey ][ key ] = realMock;
+	},
+
+	addMockFile: function( filePath, mock ) {
+		var absPath = path.resolve( this.getMockConfig( "sqlFileBasePath" ), filePath );
+		this.addMock( absPath, mock, { cacheKey: "file" } );
+	},
+
+	getMock: function( key, options ) {
+		var cacheKey = getCacheKey( options );
+		// can't mock "result" key, since
+		// that's the internal step name used
+		// when calling execute/executeTransaction
+
+		if ( _.isUndefined( this.mockCache[ cacheKey ] ) ) {
+			return undefined;
+		}
+
+		var mock = ( key === "__result__" ) ? undefined : this.mockCache[ cacheKey ][ key ];
+
+		return mock ? mock : undefined;
+	},
+	getFileMock: function( key ) {
+		if ( !isFileMock( key ) ) {
+			return undefined;
+		}
+		key = getFileMockKey( key );
+		return this.getMock( key, { cacheKey: "file" } );
+	},
+	clearFileMock: function( key ) {
+		return this.clearMock( key, { cacheKey: "file" } );
+	},
+	clearMock: function( key, options ) {
+		var cacheKey = getCacheKey( options );
+		if ( arguments.length === 0 ) {
+			this.mockCache = {};
+		} else {
+			if ( this.mockCache[ cacheKey ].hasOwnProperty( key ) ) {
+				delete this.mockCache[ cacheKey ][ key ];
+			}
+		}
+	},
+	findMockForKey: function( key ) {
+		var mock = this.getMock( key );
+
+		if ( !_.isUndefined( mock ) ) {
+			if ( mock.once ) {
+				this.clearMock( key );
+			}
+
+			return mock;
+		} else {
+			mock = this.getFileMock( key );
+
+			if ( !_.isUndefined( mock ) && mock.once ) {
+				this.clearFileMock( key );
+			}
+		}
+
+		return mock;
+	},
+	resolveMock: function( stepName, options ) {
+		// Search by:
+		// 1. Step Name
+		// 2. Query
+		// 3. Prepared SQL
+		// 4. Procedure
+
+		var mock; // undefined
+
+		mock = this.findMockForKey( stepName );
+
+		if ( !_.isUndefined( mock ) ) {
+			return mock;
+		}
+
+		if ( options.query ) {
+			mock = this.findMockForKey( options.query );
+			if ( !_.isUndefined( mock ) ) {
+				return mock;
+			}
+		}
+
+		if ( options.preparedSql ) {
+			mock = this.findMockForKey( options.preparedSql );
+
+			if ( !_.isUndefined( mock ) ) {
+				return mock;
+			}
+		}
+
+		if ( options.procedure ) {
+			mock = this.findMockForKey( options.procedure );
+
+			if ( !_.isUndefined( mock ) ) {
+				return mock;
+			}
+		}
+
+		return mock;
+	},
+
+	setMockConfig: function( config ) {
+		_.extend( this.mockConfig, config );
+	},
+
+	getMockConfig: function( key ) {
+		return this.mockConfig[ key ];
+	}
+};

--- a/src/mock.js
+++ b/src/mock.js
@@ -1,6 +1,6 @@
 var _ = require( "lodash" );
 var when = require( "when" );
-var path = require( "path" );
+var mockMethods = require( "./methods" );
 
 /* Example mock object structure
 
@@ -9,170 +9,36 @@ var path = require( "path" );
 			return []; // array of mock rows
 		},
 		isError: true/false,
-		waitTime: { milliseconds } to wait (defaults to 0)
+		waitTime: { milliseconds } to wait (defaults to 0),
+		once: false
 	}
 
 */
 
-function getCacheKey( options ) {
-	options = options || {};
-	return options.cacheKey || "root";
-}
-
-function isAbsolutePath( p ) {
-	return path.resolve( p ) === path.normalize( p ).replace( /(.+)([\/|\\])$/, "$1" );
-}
-
-function isFileMock( str ) {
-	return str.slice( 0, 7 ) === "file://";
-}
-
-function getFileMockKey( str ) {
-	return str.slice( 7 );
-}
-
-var methods = {
-	addMock: function( key, mock, options ) {
-		var cacheKey = getCacheKey( options );
-		var realMock = mock;
-		var defaults = {
-			isError: false,
-			waitTime: 0
-		};
-
-		if ( !this.mockCache[ cacheKey ] ) {
-			this.mockCache[ cacheKey ] = {};
-		}
-
-		if ( _.isFunction( realMock ) ) {
-			// Just a function was given
-			realMock = _.merge( defaults, {
-				mockResults: mock,
-			} );
-		} else if ( !_.isPlainObject( realMock ) ) {
-			// Something other than a function or object was given
-			var result = _.clone( realMock );
-			realMock = _.merge( defaults, {
-				mockResults: function() {
-					return result;
-				}
-			} );
-		} else {
-			realMock = _.merge( defaults, mock );
-		}
-
-		if ( !_.isFunction( realMock.mockResults ) ) {
-			// Ensure that mockResults is a function
-			var results = _.clone( realMock.mockResults );
-			realMock.mockResults = function() {
-				return results;
-			}
-		}
-
-		this.mockCache[ cacheKey ][ key ] = realMock;
-	},
-
-	addMockFile: function( filePath, mock ) {
-		var absPath = path.resolve( this.getMockConfig( "sqlFileBasePath" ), filePath );
-		this.addMock( absPath, mock, { cacheKey: "file" } )
-	},
-
-	getMock: function( key, options ) {
-		var cacheKey = getCacheKey( options );
-		// can't mock "result" key, since
-		// that's the internal step name used
-		// when calling execute/executeTransaction
-
-		if ( _.isUndefined( this.mockCache[ cacheKey ] ) ) {
-			return undefined;
-		}
-
-		var mock = ( key === "result" ) ? undefined : this.mockCache[ cacheKey ][ key ];
-		if ( mock ) {
-			//console.info( "Mock key found:", key );
-		}
-		return mock ? mock : undefined;
-	},
-	getFileMock: function( key ) {
-		if ( !isFileMock( key ) ) {
-			return undefined;
-		}
-		var key = getFileMockKey( key );
-		return this.getMock( key, { cacheKey: "file" } );
-	},
-	clearMock: function( key, options ) {
-		var cacheKey = getCacheKey( options );
-		if ( arguments.length === 0 ) {
-			this.mockCache = {};
-		} else {
-			if ( this.mockCache[ cacheKey ].hasOwnProperty( key ) ) {
-				delete this.mockCache[ cacheKey ][ key ];
-			}
-		}
-	},
-	findMockForKey: function( key ) {
-		var mock = this.getMock( key );
+function executeSqlFn( sql, fallbackFn ) {
+	return function( options ) {
+		var stepName = this.state;
+		var mock = sql.resolveMock( stepName, options );
 
 		if ( !_.isUndefined( mock ) ) {
-			return mock;
-		} else {
-			mock = this.getFileMock( key );
+			return when.promise( function( resolve, reject ) {
+				var results = mock.mockResults.call( this, stepName, options );
+				var timeout = mock.waitTime || 0;
+
+				setTimeout( function() {
+					if ( mock.isError ) {
+						reject( results );
+					} else {
+						resolve( results );
+					}
+				}, timeout );
+
+			}.bind( this ) );
 		}
 
-		return mock;
-	},
-	resolveMock: function( stepName, options ) {
-		// Search by:
-		// 1. Step Name
-		// 2. Query
-		// 3. Prepared SQL
-		// 4. Procedure
-		// 5. File
-
-		var mock; // undefined
-
-		mock = this.getMock( stepName );
-
-		if ( !_.isUndefined( mock ) ) {
-			return mock;
-		}
-
-		if ( options.query ) {
-			mock = this.findMockForKey( options.query );
-			if ( !_.isUndefined( mock ) ) {
-				return mock;
-			}
-		}
-
-		if ( options.preparedSql ) {
-			mock = this.findMockForKey( options.preparedSql );
-
-			if ( !_.isUndefined( mock ) ) {
-				return mock;
-			}
-		}
-
-		if ( options.procedure ) {
-			mock = this.findMockForKey( options.procedure );
-
-			if ( !_.isUndefined( mock ) ) {
-				return mock;
-			}
-		}
-
-
-
-		return mock;
-	},
-
-	setMockConfig: function( config ) {
-		_.extend( this.mockConfig, config );
-	},
-
-	getMockConfig: function( key ) {
-		return this.mockConfig[ key ];
-	}
-};
+		return fallbackFn.call( this, options );
+	};
+}
 
 module.exports = {
 
@@ -182,7 +48,7 @@ module.exports = {
 		sql.mockCache = {};
 		sql.mockConfig = {};
 
-		_.extend( sql, methods );
+		_.extend( sql, mockMethods );
 
 		var defaultConfig = {
 			ignoreFailedConnections: true
@@ -190,45 +56,15 @@ module.exports = {
 
 		sql.setMockConfig( _.merge( defaultConfig, options ) );
 
-		var origContext = sql.SqlContext;
-		var _executeSql = origContext.prototype.executeSql;
-		var _errorState = origContext.prototype.states.connecting.error;
+		this.patchSeriate( sql );
 
-		sql.SqlContext = origContext.extend( {
-			executeSql: function( options ) {
-				var stepName = this.state;
-				var mock = sql.resolveMock( stepName, options );
+		this.patchSqlContext( sql );
 
-				if ( !_.isUndefined( mock ) ) {
-					return when.promise( function( resolve, reject ) {
-						var results = mock.mockResults.call( this, stepName, options );
-						var timeout = mock.waitTime || 0;
+		this.patchTransactionContext( sql );
 
-						setTimeout( function() {
-							if ( mock.isError ) {
-								reject( results );
-							} else {
-								resolve( results );
-							}
-						}, timeout )
+	},
 
-					}.bind( this ) );
-				}
-
-				return origPrototype.executeSql.call( this, options );
-			},
-			states: {
-				connecting: {
-					error: function( err ) {
-						if ( sql.getMockConfig( "ignoreFailedConnections" ) ) {
-							return this.states.connecting.success.call( this );
-						}
-						return _errorState.call( this, err );
-					}
-				}
-			}
-		} );
-
+	patchSeriate: function( sql ) {
 		var _fromFile = sql.fromFile;
 
 		sql.fromFile = function( p ) {
@@ -243,7 +79,76 @@ module.exports = {
 			}
 
 		};
+	},
 
+	patchSqlContext: function( sql ) {
+		var origContext = sql.SqlContext;
+		var _executeSql = origContext.prototype.executeSql;
+		var _errorState = origContext.prototype.states.connecting.error;
+
+		sql.SqlContext = origContext.extend( {
+			executeSql: executeSqlFn( sql, _executeSql ),
+			states: {
+				connecting: {
+					error: function( err ) {
+						if ( sql.getMockConfig( "ignoreFailedConnections" ) ) {
+							return this.states.connecting.success.call( this );
+						}
+						return _errorState.call( this, err );
+					}
+				}
+			}
+		} );
+	},
+
+	patchTransactionContext: function( sql ) {
+		var origContext = sql.TransactionContext;
+		var _executeSql = origContext.prototype.executeSql;
+		var _errorState = origContext.prototype.states.connecting.error;
+
+		sql.TransactionContext = origContext.extend( {
+			executeSql: executeSqlFn( sql, _executeSql ),
+			states: {
+				connecting: {
+					error: function( err ) {
+						if ( sql.getMockConfig( "ignoreFailedConnections" ) ) {
+							var success = this.states.connecting.success;
+							if ( _.isString( success ) ) {
+								return this.transition( success );
+							} else {
+								return success.call( this );
+							}
+						}
+						return _errorState.call( this, err );
+					}
+				},
+				startingTransaction: {
+					_onEnter: function() {
+						return this.states.startingTransaction.success.call( this );
+					}
+				},
+				done: {
+					_onEnter: function() {
+						var self = this;
+						self.emit( "end", {
+							sets: self.results,
+							transaction: {
+								commit: function() {
+									return when.promise( function( resolve ) {
+										resolve();
+									} );
+								},
+								rollback: function() {
+									return when.promise( function( resolve ) {
+										resolve();
+									} );
+								}
+							}
+						} );
+					}
+				}
+			}
+		} );
 	}
 
 };


### PR DESCRIPTION
This is a bunch of work on the core functionality of seriate.mock. Adds the ability to mock files and transactions. Also supports single-use mocks.
